### PR TITLE
Fix typeaheadCallback search suggestions

### DIFF
--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -580,6 +580,7 @@ export default {
                         this.typeaheadCallback(searchQuery)
                             .then((results) => {
                                 this.typeaheadTags = results;
+                                this.doSearch(searchQuery);
                             });
                     } else if (this.typeaheadUrl.length > 0) {
                         this.typeaheadTags.splice(0);


### PR DESCRIPTION
As described in this issue in the original repository: https://github.com/voerro/vue-tagsinput/issues/149#issuecomment-877595366
Would be nice to be able to use your repository for now.